### PR TITLE
Feature/fgs 213

### DIFF
--- a/commands/constants.go
+++ b/commands/constants.go
@@ -106,36 +106,42 @@ type ZWaveCommand byte
 //COMMAND_CLASS_NON_INTEROPERABLE	0xF0	240
 
 const (
-	Basic                           = 0x20
-	ControllerReplication           = 0x21
-	ApplicationStatus               = 0x22
-	SwitchBinary                    = 0x25
-	SwitchMultilevel                = 0x26
-	SwitchAll                       = 0x27
-	SwitchToggleBinary              = 0x28
-	SwitchToggleMultilevel          = 0x29
-	SceneActivation                 = 0x2B
-	SceneActuatorConf               = 0x2C
-	SensorBinary                    = 0x30
-	SensorMultiLevel                = 0x31
-	Meter                           = 0x32
-	MeterPulse                      = 0x35
-	ThermostatMode                  = 0x40
-	ThermostatOperatingState        = 0x42
-	ThermostatSetpoint              = 0x43
-	ThermostatFanMode               = 0x44
-	ThermostatFanState              = 0x45
-	ClimateControlSchedule          = 0x46
-	BasicWindowCovering             = 0x50
-	AssociationGRPInfo              = 0x59
-	MultiInstance                   = 0x60
-	Configuration                   = 0x70
+	Basic                    = 0x20
+	ControllerReplication    = 0x21
+	ApplicationStatus        = 0x22
+	SwitchBinary             = 0x25
+	SwitchMultilevel         = 0x26
+	SwitchAll                = 0x27
+	SwitchToggleBinary       = 0x28
+	SwitchToggleMultilevel   = 0x29
+	SceneActivation          = 0x2B
+	SceneActuatorConf        = 0x2C
+	SensorBinary             = 0x30
+	SensorMultiLevel         = 0x31
+	Meter                    = 0x32
+	MeterPulse               = 0x35
+	ThermostatMode           = 0x40
+	ThermostatOperatingState = 0x42
+	ThermostatSetpoint       = 0x43
+	ThermostatFanMode        = 0x44
+	ThermostatFanState       = 0x45
+	ClimateControlSchedule   = 0x46
+	BasicWindowCovering      = 0x50
+	CRC16Encap               = 0x56
+	AssociationGRPInfo       = 0x59
+	DeviceResetLocally       = 0x5a
+	CentralScenev2           = 0x5b
+	ZwavePlusInfov2          = 0x5e
+	MultiInstance            = 0x60
+	Configuration            = 0x70
+	// Alarm maybe rename since 0x71 is called COMMAND_CLASS_NOTIFICATION_V5
 	Alarm                           = 0x71
 	ManufacturerSpecific            = 0x72
 	PowerLevel                      = 0x73
 	Protection                      = 0x75
 	Lock                            = 0x76
 	NodeNaming                      = 0x77
+	FirmwareUpdateMDv3              = 0x7a
 	Battery                         = 0x80
 	Clock                           = 0x81
 	Hail                            = 0x82
@@ -149,6 +155,7 @@ const (
 	MultiCmd                        = 0x8F
 	EnergyProduction                = 0x90
 	ManufacturerProprietary         = 0x91
+	Security                        = 0x98
 	AssociationCommandConfiguration = 0x9b
 	Mark                            = 0xE
 )

--- a/connection.go
+++ b/connection.go
@@ -318,8 +318,10 @@ func (conn *Connection) timeoutWorker(sp *sendPackage) {
 		if index == sp.uuid {
 			logrus.Warnf("TIMEOUT: %s", sp.uuid)
 			delete(conn.inFlight, sp.uuid)
-			close(c.returnChan)
-			c.returnChan = nil
+			if c.returnChan != nil {
+				close(c.returnChan)
+				c.returnChan = nil
+			}
 		}
 	}
 	conn.Unlock()

--- a/database/993-010f-0403-1000.xml
+++ b/database/993-010f-0403-1000.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ZWaveDevice xmlns="http://www.pepper1.net/zwavedb/xml-schemata/z-wave" schemaVersion="2">
+
+	<descriptorVersion>1</descriptorVersion>
+
+	<deviceData>
+		<manufacturerId value="010f"/>
+		<productType value="0403"/>
+		<productId value="1000"/>
+		<libType value="00"/>
+		<protoVersion value="00"/>
+		<protoSubVersion value="00"/>
+		<appVersion value="00"/>
+		<appSubVersion value="00"/>
+		<basicClass value="04"/>
+		<genericClass value="10"/>
+		<specificClass value="01"/>
+		<optional value="true"/>
+		<listening value="true"/>
+		<routing value="true"/>
+		<beamSensor>0</beamSensor>
+		<rfFrequency>EU</rfFrequency>
+
+	</deviceData>
+
+	<deviceDescription>
+		<description>
+			<lang xml:lang="en">Single Relay Switch 2 FGS-213</lang>
+		</description>
+		<wakeupNote>
+			<lang xml:lang="en"></lang>
+		</wakeupNote>
+		<inclusionNote>
+			<lang xml:lang="en">Tripple Press little button on device</lang>
+		</inclusionNote>
+		<productName>FGS-213</productName>
+		<brandName>Fibaro</brandName>
+		<productLine>Fibaro</productLine>
+		<productVersion>3.2</productVersion>
+	</deviceDescription>
+
+	<commandClasses>
+		<commandClass id="0027" />
+		<commandClass id="0022" />
+		<commandClass id="0059" />
+		<commandClass id="0085" version="2"/>
+		<commandClass id="0020" />
+		<commandClass id="005b" version="2" />
+		<commandClass id="0070" />
+		<commandClass id="0056" />
+		<commandClass id="005a" />
+		<commandClass id="007a" version="3" />
+		<commandClass id="0072" version="2" />
+		<commandClass id="0032" version="3" />
+		<commandClass id="0060" version="4" controlled="true"/>
+		<commandClass id="008E" version="3" />
+		<commandClass id="0071" version="5" />
+		<commandClass id="0073" />
+		<commandClass id="0075" version="2" />
+		<commandClass id="0098" />
+		<commandClass id="0025" controlled="true" />
+		<commandClass id="0086" version="2" />
+		<commandClass id="005E" version="2" />
+
+	</commandClasses>
+
+	<assocGroups>
+		<assocGroup number="1" maxNodes="1">
+			<description>
+				<lang xml:lang="en">"Lifeline" reports the device status and allows for assigning single device only (main controller by default).</lang>
+			</description>
+		</assocGroup>
+		<assocGroup number="2" maxNodes="5">
+			<description>
+				<lang xml:lang="en">"On/Off (S1)" is assigned to switch connected to the S1 terminal (uses Basic command class).</lang>
+			</description>
+		</assocGroup>
+		<assocGroup number="3" maxNodes="5">
+			<description>
+				<lang xml:lang="en">"Dimmer (S1)" is assigned to switch connected to the S1 terminal (uses Switch Multilevel command class).</lang>
+			</description>
+		</assocGroup>
+		<assocGroup number="4" maxNodes="5">
+			<description>
+				<lang xml:lang="en">"On/Off (S2)" is assigned to switch connected to the S2 terminal (uses Basic command class).</lang>
+			</description>
+		</assocGroup>
+		<assocGroup number="5" maxNodes="5">
+			<description>
+				<lang xml:lang="en">"Dimmer (S2)" is assigned to switch connected to the S2 terminal (uses Switch Multilevel command class).</lang>
+			</description>
+		</assocGroup>
+	</assocGroups>
+
+
+</ZWaveDevice>

--- a/database/test.go
+++ b/database/test.go
@@ -729,6 +729,8 @@ func New(manufacturerID, productType, productID string) *Device{
 		return New010f04000109() // 351-010f-0400-0109-03-03-2a-01-09.xml | 010f04000109
 	case "010f0400100a":
 		return New010f0400100a() // 665-010f-0400-100a-03-03-2a-02-01.xml | 010f0400100a
+	case "010f04031000":
+		return New010f04031000() // 993-010f-0403-1000.xml | 010f04031000
 	case "010f05010101":
 		return New010f05010101() // 428-010f-0501-0101-03-03-22-03-31.xml | 010f05010101
 	case "010f05010102":
@@ -59350,6 +59352,97 @@ func New010f0400100a() *Device{
 					},
 				},
 			},
+		},
+	}
+}
+func New010f04031000() *Device{
+	return &Device{
+		Brand: "Fibaro",
+		Product: "FGS-213",
+		Description: "\n			\n		",
+
+		ManufacturerID: "010f",
+		ProductType: "0403",
+		ProductID: "1000",
+		CommandClasses: []*CommandClass{
+			&CommandClass{
+				ID: 0x0027,
+			},
+			&CommandClass{
+				ID: 0x0022,
+			},
+			&CommandClass{
+				ID: 0x0059,
+			},
+			&CommandClass{
+				ID: 0x0085,
+				Version: "2",
+			},
+			&CommandClass{
+				ID: 0x0020,
+			},
+			&CommandClass{
+				ID: 0x005b,
+				Version: "2",
+			},
+			&CommandClass{
+				ID: 0x0070,
+			},
+			&CommandClass{
+				ID: 0x0056,
+			},
+			&CommandClass{
+				ID: 0x005a,
+			},
+			&CommandClass{
+				ID: 0x007a,
+				Version: "3",
+			},
+			&CommandClass{
+				ID: 0x0072,
+				Version: "2",
+			},
+			&CommandClass{
+				ID: 0x0032,
+				Version: "3",
+			},
+			&CommandClass{
+				ID: 0x0060,
+				Controlled: "true",
+				Version: "4",
+			},
+			&CommandClass{
+				ID: 0x008E,
+				Version: "3",
+			},
+			&CommandClass{
+				ID: 0x0071,
+				Version: "5",
+			},
+			&CommandClass{
+				ID: 0x0073,
+			},
+			&CommandClass{
+				ID: 0x0075,
+				Version: "2",
+			},
+			&CommandClass{
+				ID: 0x0098,
+			},
+			&CommandClass{
+				ID: 0x0025,
+				Controlled: "true",
+			},
+			&CommandClass{
+				ID: 0x0086,
+				Version: "2",
+			},
+			&CommandClass{
+				ID: 0x005E,
+				Version: "2",
+			},
+		},
+		Parameters: []*parameter{
 		},
 	}
 }

--- a/serialapi/get_node_protocolinfo.go
+++ b/serialapi/get_node_protocolinfo.go
@@ -22,8 +22,8 @@ type FuncGetNodeProtocolInfo struct {
 func NewGetNodeProtocolInfo(data []byte) (*FuncGetNodeProtocolInfo, error) {
 	pi := &FuncGetNodeProtocolInfo{}
 
-	if len(data) != 6 {
-		return nil, fmt.Errorf("wrong length, should be 6 bytes got %d", len(data))
+	if len(data) < 6 {
+		return nil, fmt.Errorf("wrong length, should be at least 6 bytes got len %d data: %x", len(data), data)
 	}
 
 	// Capabilities


### PR DESCRIPTION
@stamp  without a working xml file for FGS-213 it kept crashing since (n *Node) RequestStates() tries to use n.Device.CommandClasses which is nil. 


```
goroutine 55 [running]:
panic(0x82f820, 0xc42000c0c0)
        /usr/local/go/src/runtime/panic.go:500 +0x1a1
github.com/stampzilla/gozwave/nodes.(*Node).RequestStates(0xc4201b4640, 0xc42029a600, 0x0)
        /home/stampzilla/go/src/github.com/stampzilla/gozwave/nodes/request_states.go:12 +0x65
github.com/stampzilla/gozwave/nodes.(*Node).Identify(0xc4201b4640)
        /home/stampzilla/go/src/github.com/stampzilla/gozwave/nodes/node.go:224 +0x267
created by github.com/stampzilla/gozwave.(*Controller).getNodes
        /home/stampzilla/go/src/github.com/stampzilla/gozwave/controller.go:67 +0x282

```

I also discovered that the NodeProtocolInfo was 7 long and not 6 so i just changed the validation and it worked. I have not tried to understand what the 7th byte contained.

Also fixed crash here https://github.com/stampzilla/stampzilla-go/issues/72 in commit e1b6234