### PR TITLE
Fix logrus import

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -5,8 +5,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/pborman/uuid"
+	"github.com/sirupsen/logrus"
 	"github.com/stampzilla/gozwave/commands/reports"
 	"github.com/stampzilla/gozwave/interfaces"
 	"github.com/stampzilla/gozwave/serialapi"

--- a/controller.go
+++ b/controller.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/stampzilla/gozwave/commands/reports"
 	"github.com/stampzilla/gozwave/events"
 	"github.com/stampzilla/gozwave/nodes"

--- a/gozwave.go
+++ b/gozwave.go
@@ -10,7 +10,7 @@ import (
 	"io"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/tarm/serial"
 )
 

--- a/gozwave_test.go
+++ b/gozwave_test.go
@@ -8,7 +8,7 @@ import (
 	"text/tabwriter"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/stampzilla/gozwave/serialapi"
 	"github.com/stretchr/testify/assert"
 )

--- a/nodes/endpoints.go
+++ b/nodes/endpoints.go
@@ -1,7 +1,7 @@
 package nodes
 
 import (
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/stampzilla/gozwave/commands"
 	"github.com/stampzilla/gozwave/database"
 	"github.com/stampzilla/gozwave/interfaces"

--- a/nodes/node.go
+++ b/nodes/node.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/stampzilla/gozwave/commands"
 	"github.com/stampzilla/gozwave/commands/reports"
 	"github.com/stampzilla/gozwave/database"

--- a/nodes/protocol_info.go
+++ b/nodes/protocol_info.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/stampzilla/gozwave/serialapi"
 )
 

--- a/nodes/request_endpoints.go
+++ b/nodes/request_endpoints.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/stampzilla/gozwave/commands"
 	"github.com/stampzilla/gozwave/commands/reports"
 )

--- a/serialapi/message.go
+++ b/serialapi/message.go
@@ -3,7 +3,7 @@ package serialapi
 import (
 	"fmt"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 // Message is the decoded message received from the controller


### PR DESCRIPTION
Logrus changed repo name from github.com/Sirupsen/logrus to github.com/sirupsen/logrus.
It is a transitive dependency in many project gozwave should use the latest version.